### PR TITLE
feat: match all routes

### DIFF
--- a/packages/@productled/core/src/hooks/Hook.ts
+++ b/packages/@productled/core/src/hooks/Hook.ts
@@ -1,5 +1,5 @@
 interface HookTrigger {
-  url: string;
+  url: string | string[];
   selector: string;
   frequency: 'always' | 'once';  // You can add more frequency types if needed
   schedule?: Schedule;

--- a/packages/@productled/core/src/hooks/HookStore.ts
+++ b/packages/@productled/core/src/hooks/HookStore.ts
@@ -9,15 +9,16 @@ class HookStore {
 
     public addHooks(hooks: Hook[], pluginName: string) {
         for (const hook of hooks) {
-            const key = this.routeMapper.addRoute(hook.trigger.url);
-            let hooks = this.hookMap.get(key);
-            if (!hooks) {
-                hooks = [];
+            hook.plugin = pluginName;
+            const urls: string[] = Array.isArray(hook.trigger.url) ? hook.trigger.url : [hook.trigger.url];
+
+            // Register the hook for each URL provided in the trigger
+            for (const url of urls) {
+                const key = this.routeMapper.addRoute(url);
+                const hooks = this.hookMap.get(key) ?? [];
+                hooks.push(hook);
                 this.hookMap.set(key, hooks);
             }
-
-            hook.plugin = pluginName;
-            hooks.push(hook);
         }
     }
 

--- a/packages/@productled/core/src/hooks/HookStore.ts
+++ b/packages/@productled/core/src/hooks/HookStore.ts
@@ -22,12 +22,18 @@ class HookStore {
     }
 
     public getHooks(url: route): Hook[] {
-        const key = this.routeMapper.matchRoute(url);
-        if (!key) {
-            return [];
+        const keys = this.routeMapper.matchRoutes(url);
+
+        const matchedHooks: Hook[] = [];
+        for (const key of keys) {
+            const hooks = this.hookMap.get(key);
+            if (hooks) {
+                matchedHooks.push(...hooks);
+            }
         }
 
-        return this.hookMap.get(key) || [];
+        // Remove duplicate hooks
+        return Array.from(new Set(matchedHooks));
     }
 
 }

--- a/packages/@productled/core/src/routes/RouteMapper.ts
+++ b/packages/@productled/core/src/routes/RouteMapper.ts
@@ -90,18 +90,20 @@ class RouteMapper {
         this.dynamicRoutes = Object.fromEntries(sortedEntries);
     }
 
-    public matchRoute(route: string): Symbol | null {
+    public matchRoutes(route: string): Symbol[] {
+        const matched: Symbol[] = [];
+
         if (this.staticRoutes[route]) {
-            return this.staticRoutes[route];
+            matched.push(this.staticRoutes[route]);
         }
 
         for (const dynamicRoute of Object.values(this.dynamicRoutes)) {
             if (dynamicRoute.regexp.test(route)) {
-                return dynamicRoute.key;
+                matched.push(dynamicRoute.key);
             }
         }
 
-        return null;
+        return matched;
     }
 }
 


### PR DESCRIPTION
- Currently, only the most specific route is matched, and the associated hooks are executed.
- This change enables matching all possible routes and executing the relevant hooks for each in priority order.
- Supports declaring multiple URLs in the trigger (e.g., `hooks[].trigger.url: ["/home", "/users/:id"]`).